### PR TITLE
[actions] disable publish for dependabot

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,7 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the continuous integration pipeline to prevent redundant Docker image publications when triggered by automated dependency updates, reducing unnecessary builds and improving overall pipeline efficiency and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->